### PR TITLE
Remove need for installing NEXT kernel/boot files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,9 @@ if [ "$(id -u)" != "0" ]; then  #Check if script is being run as root
    echo "This script must be run as root" 1>&2
    exit 1
 fi
-
-whiptail --title "piShift Installer" --yesno "Welcome to the piShift installer. The installer will download new kernels/firmware and these could be unstable. Would you like to continue?" 8 78
 if [ ! $? = 0 ]; then
    exit 1
 else
-   sudo BRANCH=next rpi-update
    echo "dtoverlay=dwc2" | sudo tee -a /boot/config.txt
    echo "dwc2" | sudo tee -a /etc/modules
    echo "g_acm_ms" | sudo tee -a /etc/modules


### PR DESCRIPTION
Is no longer needed as OTG stuff is now in main stable kernels shipped with May/September 2016 releases.
