### PR TITLE
Add initial file in programs folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ else
    mkdir "$idir/binaries"
    mkdir "$idir/programs"
    mkdir "$idir/scripts"
+   touch "$idir/programs/test.txt"
    binf="$idir/binaries/ms.bin"
    dd if=/dev/zero of="$binf" bs=512 count=2880
    mkdosfs "$binf"


### PR DESCRIPTION
To avoid bug where script may crash if no file already exists in the programs folder.
